### PR TITLE
fix(interaction): 修复微前端环境下事件监听问题并优化事件目标检查

### DIFF
--- a/packages/interaction/interaction-web/src/Interaction.ts
+++ b/packages/interaction/interaction-web/src/Interaction.ts
@@ -21,6 +21,7 @@ export class Interaction extends InteractionBase {
 
     protected viewEvents: IObject
     protected windowEvents: IObject
+    protected eventTarget: EventTarget
 
     protected usePointer: boolean
     protected useMultiTouch: boolean
@@ -81,9 +82,12 @@ export class Interaction extends InteractionBase {
             view.addEventListener(name, viewEvents[name])
         }
 
+        // 使用 ownerDocument 替代 window，以支持微前端环境（如 wujie）
+        // 在 wujie 中，ownerDocument 被代理到 shadow root，可以正常接收事件
+        this.eventTarget = this.view.ownerDocument || window
         for (let name in windowEvents) {
             windowEvents[name] = windowEvents[name].bind(this)
-            window.addEventListener(name, windowEvents[name])
+            this.eventTarget.addEventListener(name, windowEvents[name])
         }
     }
 
@@ -97,8 +101,9 @@ export class Interaction extends InteractionBase {
             this.viewEvents = {}
         }
 
+        // 从 eventTarget（ownerDocument 或 window）移除事件监听
         for (let name in windowEvents) {
-            window.removeEventListener(name, windowEvents[name])
+            this.eventTarget.removeEventListener(name, windowEvents[name])
             this.windowEvents = {}
         }
     }
@@ -123,7 +128,15 @@ export class Interaction extends InteractionBase {
     }
 
     protected preventWindowPointer(e: UIEvent) {
-        return !this.downData && e.target !== this.view
+        // 在 shadow DOM 中，事件目标可能不是 canvas 本身
+        // 使用 composedPath 检查事件路径中是否包含 canvas
+        if (this.downData) return false
+        if (e.target === this.view) return false
+        if (e.composedPath) {
+            const path = e.composedPath()
+            return !path.includes(this.view)
+        }
+        return true
     }
 
     // key
@@ -361,6 +374,7 @@ export class Interaction extends InteractionBase {
             super.destroy()
             this.view = null
             this.touches = null
+            this.eventTarget = null
         }
     }
 


### PR DESCRIPTION
修复此问题 #800 中 `hover` 相关的问题

在 wujie 微前端中：
- JS 执行在 `iframe` 的 `window` 中
- 但 DOM（包括 `canvas`）实际渲染在主应用的 `<wujie-app>` 的 `#shadow-root` 内
- 浏览器的原生 `pointermove` 事件派发在主应用的 `document` 中，不会冒泡到 `iframe` 的 `window`
- 因此 LeaferJS 收不到相关的指针事件