### PR TITLE
Security: Plain-object registry is vulnerable to prototype pollution via arbitrary keys

### DIFF
--- a/packages/external/src/index.ts
+++ b/packages/external/src/index.ts
@@ -34,8 +34,16 @@ export const State = {
     set(): void { return Plugin.need('state') }
 } as unknown as IStateModule
 
+const transitionList = Object.create(null) as Record<string, ITransitionFunction>
+
 export const Transition = {
-    list: {},
-    register(attrName: string, fn: ITransitionFunction): void { Transition.list[attrName] = fn },
-    get(attrName: string): ITransitionFunction { return Transition.list[attrName] }
+    list: transitionList,
+    register(attrName: string, fn: ITransitionFunction): void {
+        if (attrName === '__proto__' || attrName === 'constructor' || attrName === 'prototype') return
+        Transition.list[attrName] = fn
+    },
+    get(attrName: string): ITransitionFunction {
+        if (attrName === '__proto__' || attrName === 'constructor' || attrName === 'prototype') return
+        return Transition.list[attrName]
+    }
 } as ITransitionModule


### PR DESCRIPTION
## Summary

Security: Plain-object registry is vulnerable to prototype pollution via arbitrary keys

## Problem

**Severity**: `Medium` | **File**: `packages/external/src/index.ts:L33`

Transition.list is initialized as a plain object and register() writes using an attacker-controlled attrName. Passing keys like __proto__, constructor, or prototype can mutate the object's prototype chain or corrupt registry behavior. Similar registry patterns in this codebase should use prototype-less maps.

## Solution

Use Map<string, ITransitionFunction> or Object.create(null) for registry storage, and explicitly reject special property names. Update get()/register() to treat keys as data, not object properties.

## Changes

- `packages/external/src/index.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced