### PR TITLE
fix(text): classify accented Latin as letters, not CJK ideographs

### DIFF
--- a/packages/partner/text/src/CharType.ts
+++ b/packages/partner/text/src/CharType.ts
@@ -27,6 +27,14 @@ const cjkRangeList = [
     [0x2F00, 0x2FDF], // Kangxi Radicals
     [0x2FF0, 0x2FFF], // Ideographic Description Characters
     [0x3000, 0x303F], // CJK Symbols and Punctuation
+    [0x1100, 0x11FF], // Hangul Jamo
+    [0x3040, 0x309F], // Hiragana
+    [0x30A0, 0x30FF], // Katakana
+    [0x3100, 0x312F], // Bopomofo
+    [0x3130, 0x318F], // Hangul Compatibility Jamo
+    [0x3190, 0x319F], // Kanbun
+    [0x31A0, 0x31BF], // Bopomofo Extended
+    [0x31F0, 0x31FF], // Katakana Phonetic Extensions
     [0x31C0, 0x31EF], // CJK Strokes
     [0x3200, 0x32FF], // Enclosed CJK Letters and Months
     [0x3300, 0x33FF], // CJK Compatibility
@@ -36,7 +44,7 @@ const cjkRangeList = [
     [0x2F800, 0x2FA1F], // CJK Compatibility Ideographs Supplement
 ]
 
-const cjkReg = new RegExp(cjkRangeList.map(([start, end]) => `[\\u${start.toString(16)}-\\u${end.toString(16)}]`).join('|'))
+const cjkReg = new RegExp(cjkRangeList.map(([start, end]) => `[\\u{${start.toString(16)}}-\\u{${end.toString(16)}}]`).join('|'), 'u')
 
 function mapChar(str: string): IBooleanMap {
     const map: IBooleanMap = {}


### PR DESCRIPTION
Fixes #901 — full analysis, reproduction script and validation script are in that issue.

## What was wrong

In `packages/partner/text/src/CharType.ts`, `\uXXXXX` is not a valid escape sequence without the `u` flag. For `[0x20000, 0x2A6DF]` the generated class was parsed as a space, then the **range** U+0030 → U+2A6D, then `f`. That stray range covered all accented Latin, Greek and Cyrillic letters, so `é`, `à`, `ç`… were classified as `CharType.Single` (a CJK ideograph).

Two visible consequences, one cause:

1. line breaks allowed between any two characters — `"dépendre exemple créer"` → `["dépendre exemple cré", "er"]`;
2. `textCase: 'upper'` skipped them (CJK ideographs have no case) — `"dépendre"` → `"DéPENDRE"`.

This affects every language using non-ASCII letters: French, Spanish, German, Portuguese, Polish, Russian, Greek, Turkish, Vietnamese…

## What this PR does

- uses `\u{...}` braces together with the `u` flag, so each range means what it says;
- **adds 8 blocks** to `cjkRangeList`: Hangul Jamo, Hiragana, Katakana, Bopomofo, Hangul Compatibility Jamo, Kanbun, Bopomofo Extended, Katakana Phonetic Extensions.

The second point is not cosmetic. The `u` flag **alone** would stop matching kana, bopomofo and Hangul jamo: those blocks are not in `cjkRangeList` today and currently match only *by accident*, through the stray range. Adding them explicitly makes this a strict improvement with no regression for Japanese or Korean.

Hangul **syllables** (U+AC00–U+D7AF) are deliberately left out: they are above the stray range and were already treated as letters, which is correct — Korean separates words with spaces.

The `validate-fix.mjs` script in #901 checks both directions: accented Latin freed, all real CJK preserved, zero regression across the BMP. It passes on this branch.

---

# 中文

修复 #901 —— 完整分析、复现脚本和验证脚本见该 issue。

## 问题

`packages/partner/text/src/CharType.ts` 中，在没有 `u` 标志的情况下 `\uXXXXX` 不是合法的转义序列。对于 `[0x20000, 0x2A6DF]`，生成的字符类被解析为一个空格、一个从 U+0030 到 U+2A6D 的**区间**、以及 `f`。这个意外区间覆盖了全部带重音的拉丁字母、希腊字母和西里尔字母，使 `é`、`à`、`ç` 等被判定为 `CharType.Single`（CJK 表意文字）。

同一个原因导致两个可见问题：

1. 允许在任意两个字符之间断行 —— `"dépendre exemple créer"` → `["dépendre exemple cré", "er"]`；
2. `textCase: 'upper'` 失效（CJK 表意文字没有大小写）—— `"dépendre"` → `"DéPENDRE"`。

影响所有使用非 ASCII 字母的语言：法语、西班牙语、德语、葡萄牙语、波兰语、俄语、希腊语、土耳其语、越南语等。

## 本 PR 的改动

- 使用 `\u{...}` 配合 `u` 标志，让每个区间表达其字面含义；
- 向 `cjkRangeList` **新增 8 个区块**：谚文字母、平假名、片假名、注音符号、谚文兼容字母、汉文标记、注音符号扩展、片假名音标扩展。

第二点并非可有可无：**仅**加 `u` 标志会导致假名、注音符号和谚文字母不再被判定为 CJK —— 它们目前并不在 `cjkRangeList` 中，只是**偶然**通过那个错误区间匹配上的。显式加入后，本次改动对日语和韩语没有任何回退。

谚文**音节**（U+AC00–U+D7AF）有意未加入：它们本来就在错误区间之上，一直被当作字母处理，这是正确的 —— 韩语使用空格分词。

#901 中的 `validate-fix.mjs` 对两个方向都做了验证：带重音的拉丁字母不再被误判，真正的 CJK 全部保留，在整个 BMP 范围内没有任何回退。该脚本在本分支上通过。
